### PR TITLE
variable renaming to remove some "Debian" hardcoded names

### DIFF
--- a/inventories/seapath_cluster_definition_example.yml
+++ b/inventories/seapath_cluster_definition_example.yml
@@ -350,7 +350,7 @@ all:
         extra_snmpd_directives: |
           extend crmstatus /usr/bin/timeout 1s /usr/bin/sudo -u hacluster /usr/local/bin/snmp_crmstatus.sh
         # optional extra permissions to add to Debian-snmp sudoers file
-        extra_debiansnmp_sudoers: |
+        extra_usersnmp_sudoers: |
           Debian-snmp     ALL = (hacluster) NOPASSWD:EXEC: /usr/local/bin/snmp_crmstatus.sh ""
 
         # optional conntrackd synchronization configuration. This is useful when using the hosts as routers if you want the conntrack tables to be synchronized among hosts. If conntrackd_ignore_ip_list is defined it will enable the appropriate portion of the playbook, and the content will be used as the list of IP addresses to IGNORE when synchronizing the conntrack table

--- a/inventories/seapath_standalone_definition_example.yml
+++ b/inventories/seapath_standalone_definition_example.yml
@@ -123,5 +123,5 @@ all:
                             extra_snmpd_directives: |
                               extend crmstatus /usr/bin/timeout 1s /usr/bin/sudo -u hacluster /usr/local/bin/snmp_crmstatus.sh
                             # optional extra permissions to add to Debian-snmp sudoers file
-                            extra_debiansnmp_sudoers: |
+                            extra_usersnmp_sudoers: |
                               Debian-snmp     ALL = (hacluster) NOPASSWD:EXEC: /usr/local/bin/snmp_crmstatus.sh ""

--- a/playbooks/ci_configure.yaml
+++ b/playbooks/ci_configure.yaml
@@ -13,7 +13,7 @@
   tasks:
   - name: CI configure skip setup_debian reboots
     set_fact:
-      skip_reboot_setup_debian: true
+      skip_reboot_setup: true
       skip_reboot_setup_network: true
 - import_playbook: ./cluster_setup_debian.yaml
 - import_playbook: ./cluster_setup_hardened_debian.yaml

--- a/playbooks/cluster_setup_debian.yaml
+++ b/playbooks/cluster_setup_debian.yaml
@@ -52,6 +52,6 @@
     - name: Restart to configure Debian
       reboot:
       when:
-        - skip_reboot_setup_debian is not defined or not skip_reboot_setup_debian
+        - skip_reboot_setup is not defined or not skip_reboot_setup
     - name: Wait for host to be online
       wait_for_connection:

--- a/src/debian/sudoers/Debian-snmp.j2
+++ b/src/debian/sudoers/Debian-snmp.j2
@@ -1,4 +1,4 @@
 Defaults:Debian-snmp !requiretty
-{% if extra_debiansnmp_sudoers is defined %}
-{{ extra_debiansnmp_sudoers -}}
+{% if extra_usersnmp_sudoers is defined %}
+{{ extra_usersnmp_sudoers -}}
 {% endif %}


### PR DESCRIPTION
API changes:

    changes inventory variable skip_reboot_setup_debian renaming it to skip_reboot_setup
    Inventory variable extra_debiansnmp_sudoers is changed and renamed extra_usersnmp_sudoers